### PR TITLE
Avoid posting "RESULT = 0" from unixCmd on OS X

### DIFF
--- a/ddwSnippets.sc
+++ b/ddwSnippets.sc
@@ -103,7 +103,7 @@ DDWSnippets {
 			current = keys[i];
 		},
 		post = switch(thisProcess.platform.name)  // 'switch' for future requirements
-		{ \osx } { { "osascript -e 'activate application \"SuperCollider\"'".unixCmd } };
+		{ \osx } { { "osascript -e 'activate application \"SuperCollider\"'".unixCmd(postOutput: false) } };
 
 		window = Window("Snippets",
 			Rect.aboutPoint(Window.screenBounds.center, 120, 90));


### PR DESCRIPTION
I tested this, and the osascript works great.  The only thing is to suppress the message from unixCmd.  Thanks!