### PR TITLE
Update modifiers' keycodes for macOS

### DIFF
--- a/ddwSnippets.sc
+++ b/ddwSnippets.sc
@@ -261,7 +261,7 @@ DDWSnippets {
 		// it's different for each supported OS. yup. Qt is "cross platform"
 		done = switch(thisProcess.platform.name)
 		{ \linux } { { |char, keycode| keycode bitAnd: 0xFF80 != 0xFF80 } }
-		{ \osx } { { |char, keycode| keycode > 0 } }
+		{ \osx } { { |char, keycode| (keycode > 62) or: (keycode < 54) } }
 		{ \windows } { { |char, keycode| char.ascii > 0 } };
 
 		rout = fork({


### PR DESCRIPTION
Fixes #4

Here are modifier keycodes, as reported on macOS 10.14 with SC 3.12.1:
```
54: cmd R
55: cmd L
56: shift L
57: (unknown)
58: alt L
59: ctrl L
60: shift R
61: alt R
62: ctrl R
```
What do you think @jamshark70 ?